### PR TITLE
Set the user-agent string for BQ storage.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,18 +8,25 @@ lazy val commonSettings = Seq(
   spName := "google/spark-bigquery",
   sparkComponents ++= Seq("core", "sql")
 )
+
 // TODO(pmkc): Migrate off Spark Packages for simplicity
+
 // TODO(pmkc): Suppport publishing to Maven Central
 
 // Default IntegrationTest config uses separate test directory, build files
 lazy val ITest = config("it") extend Test
+
 lazy val shaded = (project in file("."))
+    .enablePlugins(BuildInfoPlugin)
     .configs(ITest)
     .settings(
       commonSettings,
       inConfig(ITest)(Defaults.testTasks),
       testOptions in Test := Seq(Tests.Filter(unitFilter)),
-      testOptions in ITest := Seq(Tests.Filter(itFilter)))
+      testOptions in ITest := Seq(Tests.Filter(itFilter)),
+      buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
+      buildInfoPackage := "com.google.cloud.spark.bigquery")
+
 // Exclude dependencies already on Spark's Classpath
 val excludedOrgs = Seq(
   // All use commons-cli:1.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,3 +3,5 @@ resolvers += "bintray-spark-packages" at "https://dl.bintray.com/spark-packages/
 addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.6")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
+
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")

--- a/src/main/scala/com/google/cloud/spark/bigquery/direct/DirectBigQueryRelation.scala
+++ b/src/main/scala/com/google/cloud/spark/bigquery/direct/DirectBigQueryRelation.scala
@@ -143,9 +143,6 @@ private[bigquery] class DirectBigQueryRelation(
 }
 
 object DirectBigQueryRelation {
-  def createHeaderProvider(): HeaderProvider = {
-    FixedHeaderProvider.create("user-agent", BuildInfo.name + "/" + BuildInfo.version)
-  }
   def createReadClient(): BigQueryStorageClient = {
     // TODO(#6): create settings provider for parameterizable auth
     // TODO(pmkc): investigate thread pool sizing and log spam matching
@@ -153,7 +150,8 @@ object DirectBigQueryRelation {
     var clientSettings = BigQueryStorageSettings.newBuilder()
       .setTransportChannelProvider(
         BigQueryStorageSettings.defaultGrpcTransportProviderBuilder()
-          .setHeaderProvider(createHeaderProvider())
+          .setHeaderProvider(
+            FixedHeaderProvider.create("user-agent", BuildInfo.name + "/" + BuildInfo.version))
           .build())
       .build()
     BigQueryStorageClient.create(clientSettings)

--- a/src/main/scala/com/google/cloud/spark/bigquery/direct/DirectBigQueryRelation.scala
+++ b/src/main/scala/com/google/cloud/spark/bigquery/direct/DirectBigQueryRelation.scala
@@ -17,7 +17,8 @@ package com.google.cloud.spark.bigquery.direct
 
 import java.sql.{Date, Timestamp}
 
-import com.google.cloud.bigquery.storage.v1beta1.BigQueryStorageClient
+import com.google.api.gax.rpc.FixedHeaderProvider
+import com.google.cloud.bigquery.storage.v1beta1.{BigQueryStorageClient, BigQueryStorageSettings}
 import com.google.cloud.bigquery.storage.v1beta1.ReadOptions.TableReadOptions
 import com.google.cloud.bigquery.storage.v1beta1.Storage.{CreateReadSessionRequest, DataFormat}
 import com.google.cloud.bigquery.storage.v1beta1.TableReferenceProto.TableReference
@@ -146,7 +147,10 @@ object DirectBigQueryRelation {
     // TODO(#6): create settings provider for parameterizable auth
     // TODO(pmkc): investigate thread pool sizing and log spam matching
     // https://github.com/grpc/grpc-java/issues/4544 in integration tests
-    BigQueryStorageClient.create
+    var clientSettings = BigQueryStorageSettings.newBuilder()
+      .setHeaderProvider(FixedHeaderProvider.create("user-agent", "spark-bigquery"))
+      .build()
+    BigQueryStorageClient.create(clientSettings)
   }
 
   def isComparable(dataType: DataType): Boolean = dataType match {

--- a/src/main/scala/com/google/cloud/spark/bigquery/direct/DirectBigQueryRelation.scala
+++ b/src/main/scala/com/google/cloud/spark/bigquery/direct/DirectBigQueryRelation.scala
@@ -23,7 +23,7 @@ import com.google.cloud.bigquery.storage.v1beta1.ReadOptions.TableReadOptions
 import com.google.cloud.bigquery.storage.v1beta1.Storage.{CreateReadSessionRequest, DataFormat}
 import com.google.cloud.bigquery.storage.v1beta1.TableReferenceProto.TableReference
 import com.google.cloud.bigquery.{Schema, StandardTableDefinition, TableDefinition, TableInfo}
-import com.google.cloud.spark.bigquery.{BigQueryRelation, SparkBigQueryOptions}
+import com.google.cloud.spark.bigquery.{BigQueryRelation, BuildInfo, SparkBigQueryOptions}
 import com.typesafe.scalalogging.Logger
 import org.apache.spark.Partition
 import org.apache.spark.rdd.RDD
@@ -148,7 +148,8 @@ object DirectBigQueryRelation {
     // TODO(pmkc): investigate thread pool sizing and log spam matching
     // https://github.com/grpc/grpc-java/issues/4544 in integration tests
     var clientSettings = BigQueryStorageSettings.newBuilder()
-      .setHeaderProvider(FixedHeaderProvider.create("user-agent", "spark-bigquery"))
+      .setHeaderProvider(
+        FixedHeaderProvider.create("user-agent", BuildInfo.name + "/" + BuildInfo.version))
       .build()
     BigQueryStorageClient.create(clientSettings)
   }


### PR DESCRIPTION
This change modifies the build process to automatically generate build-time configuration
constants such as project name and version, and uses them to generate a user-agent string
when constructing a new BigQuery storage client object.