### PR TITLE
Add a missing '%' in SBT dependency instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ To include the connector in your project:
 ### SBT
 
 ```sbt
-libraryDependencies += "com.google.cloud.spark" % "spark-bigquery" % "0.5.1-beta"
+libraryDependencies += "com.google.cloud.spark" %% "spark-bigquery" % "0.5.1-beta"
 ```
 
 ## API


### PR DESCRIPTION
We need to use `%%` to make SBT add the `2.11` suffix to the artifact id, as explained on https://www.scala-sbt.org/1.x/docs/Library-Dependencies.html#Getting+the+right+Scala+version+with