### PR TITLE
Replace the manual skewing code with the BALANCED sharding strategy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 0.7.0-beta - 2019-06-26
+* Switch to using the BALANCED sharding strategy, which balances work between
+  streams on the server-side, leading to a more uniform distribution of rows
+  between partitions
+
 ## 0.6.0-beta - 2019-06-25
 * Support specifiying credentials through configurations
 

--- a/README.md
+++ b/README.md
@@ -174,30 +174,6 @@ The API Supports a number of options to configure the read
 <a href="#configuring-partitioning">Configuring Partitioning</a>.)
    </td>
   </tr>
-  <tr>
-   <td><code>skewLimit</code>
-   </td>
-   <td>A soft limit to how many extra rows each partition will read after reading the expected number of rows (total rows / # partitions) for that partition.
-<p>
-It is a float representing the ratio of the limit to the expected number of rows e.g 2.0 allows each partition to be twice as large as expected.
-<p>
-Must be at least 1.0.
-<p>
-
-<p>
-(Optional. Defaults to 1.5 (150%). See
-
-<a href="#configuring-partitioning">Configuring Partitioning</a>.)
-   </td>
-  </tr>
-  <tr>
-   <td><code>filter</code>
-   </td>
-   <td>A manual predicate filter expression to pass to pass to BigQuery.
-<p>
-(Optional see <a href="#filtering">filtering</a>)
-   </td>
-  </tr>
 </table>
 
 ### Data types
@@ -356,8 +332,6 @@ By default the connector creates one partition per current core available (Spark
 
 If not all partitions are currently being read some partitions may grow larger and some may be smaller or even empty. The fraction that partitions are allowed to grow beyond the expected total number of rows / number of partitions is bounded by the <code>
 
-[skewLimit](#properties)</code> parameter. The limit is soft and does not guarantee exact partitioning especially on small tables.
-
 ## Building the Connector
 
 The connector is built using [SBT](https://www.scala-sbt.org/):
@@ -377,14 +351,6 @@ See the [BigQuery pricing documentation](https://cloud.google.com/bigquery/prici
 You can manually set the number of partitions with the `parallelism` property. BigQuery may provide fewer partitions than you ask for. See [Configuring Partitioning](#configuring-partitioning).
 
 You can also always repartition after reading in Spark.
-
-### I have empty partitions
-
-Because the Storage API balances records between partitions as you read, if you don't schedule all of your map tasks concurrently, the last scheduled partitions may be empty.
-
-Decreasing the skewLimit parameter to 1.0 (or something near it) should make your parttions more uniform (at the expense of tail latency). Alternatively you can increase your cluster size to schedule all partitions concurrently. See [Configuring Partitioning](#configuring-partitioning)
-
-You can also always repartition after reading in Spark, which should remove the empty partitions.
 
 ### How do I write to BigQuery?
 

--- a/src/main/scala/com/google/cloud/spark/bigquery/SchemaConverters.scala
+++ b/src/main/scala/com/google/cloud/spark/bigquery/SchemaConverters.scala
@@ -115,7 +115,8 @@ object SchemaConverters {
         case BYTES => getBytes(value.asInstanceOf[ByteBuffer])
         case NUMERIC =>
           val bytes = getBytes(value.asInstanceOf[ByteBuffer])
-          Decimal(BigDecimal(BigInt(bytes), BQ_NUMERIC_SCALE), BQ_NUMERIC_PRECISION, BQ_NUMERIC_SCALE)
+          Decimal(BigDecimal(BigInt(bytes), BQ_NUMERIC_SCALE), BQ_NUMERIC_PRECISION,
+            BQ_NUMERIC_SCALE)
         case RECORD =>
           val fields = field.getSubFields.asScala
           convertAll(fields, value.asInstanceOf[GenericRecord], fields.map(_.getName))

--- a/src/main/scala/com/google/cloud/spark/bigquery/SparkBigQueryOptions.scala
+++ b/src/main/scala/com/google/cloud/spark/bigquery/SparkBigQueryOptions.scala
@@ -32,7 +32,6 @@ case class SparkBigQueryOptions(
     credentialsFile: Option[String] = None,
     filter: Option[String] = None,
     schema: Option[StructType] = None,
-    skewLimit: Double = SparkBigQueryOptions.SKEW_LIMIT_DEFAULT,
     parallelism: Option[Int] = None) {
 
   def createCredentials: Option[Credentials] =
@@ -51,8 +50,6 @@ case class SparkBigQueryOptions(
 
 /** Resolvers for {@link SparkBigQueryOptions} */
 object SparkBigQueryOptions {
-  private val SKEW_LIMIT_KEY = "skewLimit"
-  private val SKEW_LIMIT_DEFAULT = 1.5
 
   def apply(
       parameters: Map[String, String],
@@ -71,13 +68,9 @@ object SparkBigQueryOptions {
       defaultBilledProject)
     val filter = getOption(parameters, "filter")
     val parallelism = getOption(parameters, "parallelism").map(_.toInt)
-    val skewLimit = getOption(parameters, SKEW_LIMIT_KEY).map(_.toDouble)
-        .getOrElse(SKEW_LIMIT_DEFAULT)
-    // BigQuery will actually error if we close the last stream.
-    assert(skewLimit >= 1.0,
-      s"Paramater '$SKEW_LIMIT_KEY' must be at least 1.0 to read all data '$skewLimit'")
+
     SparkBigQueryOptions(tableId, parentProject, credsParam, credsFileParam,
-      filter, schema, skewLimit, parallelism)
+      filter, schema, parallelism)
   }
 
 

--- a/src/test/scala/com/google/cloud/spark/bigquery/it/IntegrationTestUtils.scala
+++ b/src/test/scala/com/google/cloud/spark/bigquery/it/IntegrationTestUtils.scala
@@ -39,7 +39,7 @@ object IntegrationTestUtils {
 
   def deleteDatasetAndTables(dataset: String): Unit = {
     val bq = getBigquery
-    log.warn(s"Deleting test dataset '$dataset' and it's contents")
+    log.warn(s"Deleting test dataset '$dataset' and its contents")
     bq.delete(DatasetId.of(dataset), DatasetDeleteOption.deleteContents())
   }
 }

--- a/src/test/scala/com/google/cloud/spark/bigquery/it/SparkBigQueryEndToEndITSuite.scala
+++ b/src/test/scala/com/google/cloud/spark/bigquery/it/SparkBigQueryEndToEndITSuite.scala
@@ -177,7 +177,8 @@ class SparkBigQueryEndToEndITSuite extends FunSuite
       // is on a range of rows because rows are assigned to streams on the server-side in
       // indivisible units of many rows.
       val numRowsLowerBound = LARGE_TABLE_NUM_ROWS / df.rdd.getNumPartitions
-      assert(numRowsLowerBound to (numRowsLowerBound * 1.1).toInt contains sizeOfFirstPartition)
+      assert(numRowsLowerBound <= sizeOfFirstPartition &&
+          sizeOfFirstPartition < (numRowsLowerBound * 1.1).toInt)
     }
   }
 }

--- a/src/test/scala/com/google/cloud/spark/bigquery/it/SparkBigQueryEndToEndITSuite.scala
+++ b/src/test/scala/com/google/cloud/spark/bigquery/it/SparkBigQueryEndToEndITSuite.scala
@@ -159,25 +159,25 @@ class SparkBigQueryEndToEndITSuite extends FunSuite
     }
   }
 
-  test("bounded partition skew") {
+  test("balanced partitions") {
     import com.google.cloud.spark.bigquery._
-    // Usually finishes in 10, but there is a long tail.
-    // TODO(pmkc): lower limit and add retries?
-    failAfter(30 seconds) {
+    failAfter(60 seconds) {
       // Select first partition
       val df = spark.read
-          .option("parallelism", 999)
-          .option("skewLimit", 1.0)
+          .option("parallelism", 5)
           .bigquery(LARGE_TABLE)
           .select(LARGE_TABLE_FIELD) // minimize payload
       val sizeOfFirstPartition = df.rdd.mapPartitionsWithIndex {
         case (0, it) => it
         case _ => Iterator.empty
       }.count
-      // skewLimit is a soft limit and BigQuery can send an arbitrary amount of additional rows.
-      // In this case it is usually 2X (booleans can be read very fast). In some rare cases
-      // this can grow by a lot thus we assert that we see less than 10X desired.
-      assert(sizeOfFirstPartition < (LARGE_TABLE_NUM_ROWS * 10.0 / df.rdd.getNumPartitions))
+
+      // Since we are only reading from a single stream, we can expect to get at least as many rows
+      // in that stream as a perfectly uniform distribution would command. Note that the assertion
+      // is on a range of rows because rows are assigned to streams on the server-side in
+      // indivisible units of many rows.
+      val numRowsLowerBound = LARGE_TABLE_NUM_ROWS / df.rdd.getNumPartitions
+      assert(numRowsLowerBound to (numRowsLowerBound * 1.1).toInt contains sizeOfFirstPartition)
     }
   }
 }


### PR DESCRIPTION
The BALANCED sharding strategy ensures balance among many streams on the
server-side, obviating the need for the client to mimic such behavior. Note that
I'm using an unknown field to force the BALANCED sharding strategy. We are in
the process of releasing new Java libraries. Once the new libraries are out, I
will send another pull request to use the generated code for setting the
sharding strategy.