### PR TITLE
Update the BigQuery Storage API client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,11 +54,10 @@ val relocationPrefix = s"$myPackage.repackaged"
 
 libraryDependencies ++= Seq(
   // Keep com.google.cloud dependencies in sync
-  "com.google.cloud" % "google-cloud-bigquery" % "1.61.0",
-  // Note BigQuery Storage Generated Library is Alpha but the API is Beta
-  "com.google.cloud" % "google-cloud-bigquerystorage" % "0.88.0-alpha",
+  "com.google.cloud" % "google-cloud-bigquery" % "1.82.0",
+  "com.google.cloud" % "google-cloud-bigquerystorage" % "0.98.0-beta",
   // Keep in sync with com.google.cloud
-  "io.grpc" % "grpc-netty-shaded" % "1.17.1",
+  "io.grpc" % "grpc-netty-shaded" % "1.22.1",
 
   "org.apache.avro" % "avro" % "1.8.2",
 


### PR DESCRIPTION
As part of this change, we can now call setShardingStrategy() instead of relying on the unknown fields proto API for setting the sharding strategy.