### PR TITLE
Update filtering support.

### DIFF
--- a/src/main/scala/com/google/cloud/spark/bigquery/direct/DirectBigQueryRelation.scala
+++ b/src/main/scala/com/google/cloud/spark/bigquery/direct/DirectBigQueryRelation.scala
@@ -31,7 +31,6 @@ import org.apache.spark.Partition
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.sources._
-import org.apache.spark.sql.types._
 
 import scala.collection.JavaConverters._
 
@@ -129,8 +128,7 @@ private[bigquery] class DirectBigQueryRelation(
   }
 
   private def handledFilters(filters: Array[Filter]): Array[Filter] = {
-    // We can currently only support one filter. So find first that is handled.
-    filters.find(filter => DirectBigQueryRelation.isHandled(filter, schema)).toArray
+    filters.filter(filter => DirectBigQueryRelation.isHandled(filter))
   }
 
   override def unhandledFilters(filters: Array[Filter]): Array[Filter] = {
@@ -166,37 +164,49 @@ object DirectBigQueryRelation {
     BigQueryStorageClient.create(clientSettings.build)
   }
 
-  def isComparable(dataType: DataType): Boolean = dataType match {
-    case LongType | IntegerType | ByteType => true
-    case DoubleType | FloatType | ShortType => true
-    case StringType => true
-    case _ => false
-  }
-
-  def isHandled(filter: Filter, schema: StructType): Boolean = filter match {
-    case GreaterThan(_, _) | GreaterThanOrEqual(_, _) | LessThan(_, _) | LessThanOrEqual(_, _)
-    => filter.references.forall(col => isComparable(schema(col).dataType))
+  def isHandled(filter: Filter): Boolean = filter match {
     case EqualTo(_, _) => true
-    // Includes And, Or IsNull, is
+    // There is no direct equivalent of EqualNullSafe in Google standard SQL.
+    case EqualNullSafe(_, _) => false
+    case GreaterThan(_, _) => true
+    case GreaterThanOrEqual(_, _) => true
+    case LessThan(_, _) => true
+    case LessThanOrEqual(_, _) => true
+    case In(_, _) => true
+    case IsNull(_) => true
+    case IsNotNull(_) => true
+    case And(lhs, rhs) => isHandled(lhs) && isHandled(rhs)
+    case Or(lhs, rhs) => isHandled(lhs) && isHandled(rhs)
+    case Not(child) => isHandled(child)
+    case StringStartsWith(_, _) => true
+    case StringEndsWith(_, _) => true
+    case StringContains(_, _) => true
     case _ => false
   }
 
-  // Mostly stolen from JDBCRDD.scala
-
+  // Mostly copied from JDBCRDD.scala
   def compileFilter(filter: Filter): String = filter match {
+    case EqualTo(attr, value) => s"${quote(attr)} = ${compileValue(value)}"
     case GreaterThan(attr, value) => s"$attr > ${compileValue(value)}"
-    case GreaterThanOrEqual(attr, value) => s"$attr >= ${compileValue(value)}"
-    case LessThan(attr, value) => s"$attr < ${compileValue(value)}"
-    case LessThanOrEqual(attr, value) => s"$attr <= ${compileValue(value)}"
-    case EqualTo(attr, value) => s"$attr = ${compileValue(value)}"
+    case GreaterThanOrEqual(attr, value) => s"${quote(attr)} >= ${compileValue(value)}"
+    case LessThan(attr, value) => s"${quote(attr)} < ${compileValue(value)}"
+    case LessThanOrEqual(attr, value) => s"${quote(attr)} <= ${compileValue(value)}"
+    case In(attr, values) => s"${quote(attr)} IN UNNEST(${compileValue(values)})"
+    case IsNull(attr) => s"${quote(attr)} IS NULL"
+    case IsNotNull(attr) => s"${quote(attr)} IS NOT NULL"
+    case And(lhs, rhs) => Seq(lhs, rhs).map(compileFilter).map(p => s"($p)").mkString(" AND ")
+    case Or(lhs, rhs) => Seq(lhs, rhs).map(compileFilter).map(p => s"($p)").mkString(" OR ")
+    case Not(child) => Seq(child).map(compileFilter).map(p => s"(NOT ($p))").mkString
+    case StringStartsWith(attr, value) =>
+      s"${quote(attr)} LIKE '''${value.replace("'", "\\'")}%'''"
+    case StringEndsWith(attr, value) =>
+      s"${quote(attr)} LIKE '''%${value.replace("'", "\\'")}'''"
+    case StringContains(attr, value) =>
+      s"${quote(attr)} LIKE '''%${value.replace("'", "\\'")}%'''"
     case _ => throw new IllegalArgumentException(s"Invalid filter: $filter")
   }
 
   def compileFilters(filters: Iterable[Filter]): String = {
-    // TODO remove when AND is supported
-    if (filters.size > 1) {
-      throw new IllegalArgumentException("Cannot support multiple filters")
-    }
     filters.map(compileFilter).toSeq.sorted.mkString(" AND ")
   }
 
@@ -205,11 +215,14 @@ object DirectBigQueryRelation {
    */
   private def compileValue(value: Any): Any = value match {
     case null => "null"
-    case stringValue: String => s"'${stringValue.replace("'", "''")}'"
+    case stringValue: String => s"'${stringValue.replace("'", "\\'")}'"
     case timestampValue: Timestamp => "'" + timestampValue + "'"
     case dateValue: Date => "'" + dateValue + "'"
-    case arrayValue: Array[Any] =>
-      throw new IllegalArgumentException("Cannot compare array values in filter")
+    case arrayValue: Array[Any] => arrayValue.map(compileValue).mkString("[", ", ", "]")
     case _ => value
+  }
+
+  private def quote(attr: String): String = {
+    s"""`$attr`"""
   }
 }

--- a/src/test/scala/com/google/cloud/spark/bigquery/DirectBigQueryRelationSuite.scala
+++ b/src/test/scala/com/google/cloud/spark/bigquery/DirectBigQueryRelationSuite.scala
@@ -79,35 +79,39 @@ class DirectBigQueryRelationSuite
 
   test("valid filters") {
     val validFilters = Seq(
-      GreaterThan("foo", "aardvark"),
       EqualTo("foo", "manatee"),
+      GreaterThan("foo", "aardvark"),
+      GreaterThanOrEqual("bar", 2),
       LessThan("foo", "zebra"),
       LessThanOrEqual("bar", 1),
-      GreaterThanOrEqual("bar", 2)
+      In("foo", Array(1, 2, 3)),
+      IsNull("foo"),
+      IsNotNull("foo"),
+      And(IsNull("foo"), IsNotNull("bar")),
+      Or(IsNull("foo"), IsNotNull("foo")),
+      Not(IsNull("foo")),
+      StringStartsWith("foo", "abc"),
+      StringEndsWith("foo", "def"),
+      StringContains("foo", "abcdef")
     )
     validFilters.foreach { f =>
       assert(bigQueryRelation.unhandledFilters(Array(f)).isEmpty)
     }
   }
 
-  test("only first filter is valid") {
+  test("multiple valid filters are handled") {
     val valid1 = EqualTo("foo", "bar")
     val valid2 = EqualTo("bar", 1)
-    val unhandled = bigQueryRelation.unhandledFilters(Array(valid1, valid2))
-    unhandled should (have length 1 and contain(valid2))
+    assert(bigQueryRelation.unhandledFilters(Array(valid1, valid2)).isEmpty)
   }
 
   test("invalid filters") {
     val valid1 = EqualTo("foo", "bar")
     val valid2 = EqualTo("bar", 1)
-    val invalidFilters: Array[Filter] = Array(
-      IsNotNull("foo"),
-      IsNull("foo"),
-      Or(valid1, valid2),
-      And(valid1, valid2)
-    )
-    val unhandled = bigQueryRelation.unhandledFilters(invalidFilters)
-    unhandled should contain allElementsOf invalidFilters
+    val invalid1 = EqualNullSafe("foo", "bar")
+    val invalid2 = And(EqualTo("foo", "bar"), Not(EqualNullSafe("bar", 1)))
+    val unhandled = bigQueryRelation.unhandledFilters(Array(valid1, valid2, invalid1, invalid2))
+    unhandled should contain allElementsOf Array(invalid1, invalid2)
   }
 }
 


### PR DESCRIPTION
This change modifies the filtering support in the direct BigQuery
relation to reflect the full set of filters which are supported by
the storage API. Notably, this includes:
- Support for multi-clause predicates (e.g. AND, OR, and NOT).
- Support for pseudo-column variables (_PARTITIONDATE) for ingestion
  time partitioned tables.
- Support for additional filter operations (IsNull, IsNotNull, In,
  StringStartsWith, StringEndsWith, StringContains).