### PR TITLE
Switch requested partitions from SparkContext.defaultParallelism to o…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.9.0-beta - 2019-XX-XX
+
+* Switch requested partitions from SparkContext.defaultParallelism to one
+  partition per 400MB. This should work better with balanced sharding and
+  dynamic allocation.
+
 ## 0.8.0-beta - 2019-07-22
 * Upgrade version of google-cloud-bigquery library to 1.82.0
 * Upgrade version of google-cloud-bigquerystorage library to 0.98.0-beta

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ The API Supports a number of options to configure the read
    </td>
    <td>The number of partitions to split the data into. Actual number may be less if BigQuery deems the data small enough. If there are not enough executors to schedule a reader per partition, some partitions may be empty.
 <p>
-(Optional. Defaults to <code>SparkContext.getDefaultParallelism()</code>. See
+(Optional. Defaults to one partition per 400MB. See
 <a href="#configuring-partitioning">Configuring Partitioning</a>.)
    </td>
   </tr>
@@ -324,7 +324,8 @@ You can also manually specify the `filter` option, which will override automatic
 
 ### Configuring Partitioning
 
-By default the connector creates one partition per current core available (Spark Default Parallelism) to get maximum concurrent bandwidth. This can be configured explicitly with the <code>[parallelism](#properties)</code> property. BigQuery may limit the number of partitions based on server constraints.
+By default the connector creates one partition per 400MB in the table being read (before filtering). This should roughly correspond to the maximum number of readers supported by the BigQuery Storage API. 
+This can be configured explicitly with the <code>[parallelism](#properties)</code> property. BigQuery may limit the number of partitions based on server constraints.
 
 ## Building the Connector
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 lazy val commonSettings = Seq(
   organization := "com.google.cloud.spark",
   name := "spark-bigquery",
-  version := "0.8.0-beta-SNAPSHOT",
+  version := "0.9.0-beta-SNAPSHOT",
   scalaVersion := "2.11.8",
   crossScalaVersions := Seq("2.10.5"),
   sparkVersion := "2.3.2",

--- a/src/test/scala/com/google/cloud/spark/bigquery/DirectBigQueryRelationSuite.scala
+++ b/src/test/scala/com/google/cloud/spark/bigquery/DirectBigQueryRelationSuite.scala
@@ -42,7 +42,7 @@ class DirectBigQueryRelationSuite
           Field.of("foo", LegacySQLTypeName.STRING),
           Field.of("bar", LegacySQLTypeName.INTEGER))
         )
-        .setNumBytes(42L)
+        .setNumBytes(42L * 1000 * 1000 * 1000)  // 42GB
         .build())
   private var bigQueryRelation: DirectBigQueryRelation = _
 
@@ -57,7 +57,11 @@ class DirectBigQueryRelationSuite
   }
 
   test("size in bytes") {
-    assert(42 == bigQueryRelation.sizeInBytes)
+    assert(42L * 1000 * 1000 * 1000 == bigQueryRelation.sizeInBytes)
+  }
+
+  test("parallelism") {
+    assert(105  == bigQueryRelation.getNumPartitionsRequested)
   }
 
   test("schema") {

--- a/src/test/scala/com/google/cloud/spark/bigquery/it/SparkBigQueryEndToEndITSuite.scala
+++ b/src/test/scala/com/google/cloud/spark/bigquery/it/SparkBigQueryEndToEndITSuite.scala
@@ -147,12 +147,10 @@ class SparkBigQueryEndToEndITSuite extends FunSuite
   }
 
   test("default number of partitions") {
-    // This should be stable in our master local test environment.
-    val expectedParallelism = spark.sparkContext.defaultParallelism
     val df = spark.read.format("com.google.cloud.spark.bigquery")
         .option("table", LARGE_TABLE)
         .load()
-    assert(expectedParallelism == df.rdd.getNumPartitions)
+    assert(df.rdd.getNumPartitions == 35)
   }
 
   test("read data types") {


### PR DESCRIPTION
…ne partition per 400MB.

This should work better with balanced sharding and dynamic allocation.

I believe 400MB is the correct number based on the API internals, but we could lower it to 128MB to be consistent with GCS and just let the API correct it.

I also add pretty scary log spam about the API decreasing the number of partitions, but I think this will give users clarity.

Fixes #48.