### PR TITLE
Minor fixes

### DIFF
--- a/src/main/scala/com/google/cloud/spark/bigquery/BigQueryInsertableRelation.scala
+++ b/src/main/scala/com/google/cloud/spark/bigquery/BigQueryInsertableRelation.scala
@@ -18,7 +18,7 @@ package com.google.cloud.spark.bigquery
 import java.math.BigInteger
 
 import com.google.cloud.bigquery.{BigQuery, TableDefinition}
-import com.typesafe.scalalogging.StrictLogging
+import com.typesafe.scalalogging.Logger
 import org.apache.spark.sql.sources.{BaseRelation, InsertableRelation}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
@@ -32,9 +32,9 @@ case class BigQueryInsertableRelation(val bigQuery: BigQuery,
                                       val sqlContext: SQLContext,
                                       val options: SparkBigQueryOptions)
   extends BaseRelation
-    with InsertableRelation
-    with StrictLogging {
+    with InsertableRelation {
 
+  private val logger = Logger(getClass)
 
   override def insert(data: DataFrame, overwrite: Boolean): Unit = {
     logger.info(s"insert data=${data}, overwrite=$overwrite")

--- a/src/main/scala/com/google/cloud/spark/bigquery/BigQueryInsertableRelation.scala
+++ b/src/main/scala/com/google/cloud/spark/bigquery/BigQueryInsertableRelation.scala
@@ -37,7 +37,7 @@ case class BigQueryInsertableRelation(val bigQuery: BigQuery,
   private val logger = Logger(getClass)
 
   override def insert(data: DataFrame, overwrite: Boolean): Unit = {
-    logger.info(s"insert data=${data}, overwrite=$overwrite")
+    logger.debug(s"insert data=${data}, overwrite=$overwrite")
     // the helper also supports the v2 api
     val saveMode = if (overwrite) SaveMode.Overwrite else SaveMode.Append
     val helper = BigQueryWriteHelper(bigQuery, sqlContext, saveMode, options, data)

--- a/src/main/scala/com/google/cloud/spark/bigquery/BigQueryRelation.scala
+++ b/src/main/scala/com/google/cloud/spark/bigquery/BigQueryRelation.scala
@@ -16,7 +16,6 @@
 package com.google.cloud.spark.bigquery
 
 import com.google.cloud.bigquery.{TableDefinition, TableId, TableInfo}
-import com.typesafe.scalalogging.StrictLogging
 import org.apache.spark.sql._
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.StructType
@@ -24,7 +23,7 @@ import org.apache.spark.sql.types.StructType
 /** Base BigQuery relation that uses google-cloud-bigquery to get table metadata */
 private[bigquery] case class BigQueryRelation(options: SparkBigQueryOptions, table: TableInfo)
     (@transient val sqlContext: SQLContext)
-    extends BaseRelation  with StrictLogging {
+    extends BaseRelation {
 
   val tableId: TableId = table.getTableId
   val tableName: String = BigQueryUtil.friendlyTableName(tableId)

--- a/src/main/scala/com/google/cloud/spark/bigquery/BigQueryRelationProvider.scala
+++ b/src/main/scala/com/google/cloud/spark/bigquery/BigQueryRelationProvider.scala
@@ -19,6 +19,7 @@ import com.google.auth.Credentials
 import com.google.cloud.bigquery.TableDefinition.Type.TABLE
 import com.google.cloud.bigquery.{BigQuery, BigQueryOptions, TableDefinition}
 import com.google.cloud.spark.bigquery.direct.DirectBigQueryRelation
+import com.typesafe.scalalogging.StrictLogging
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}

--- a/src/main/scala/com/google/cloud/spark/bigquery/BigQueryRelationProvider.scala
+++ b/src/main/scala/com/google/cloud/spark/bigquery/BigQueryRelationProvider.scala
@@ -19,7 +19,6 @@ import com.google.auth.Credentials
 import com.google.cloud.bigquery.TableDefinition.Type.TABLE
 import com.google.cloud.bigquery.{BigQuery, BigQueryOptions, TableDefinition}
 import com.google.cloud.spark.bigquery.direct.DirectBigQueryRelation
-import com.typesafe.scalalogging.StrictLogging
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}

--- a/src/main/scala/com/google/cloud/spark/bigquery/BigQueryWriteHelper.scala
+++ b/src/main/scala/com/google/cloud/spark/bigquery/BigQueryWriteHelper.scala
@@ -20,6 +20,7 @@ import java.util.UUID
 import com.google.cloud.bigquery.{BigQuery, BigQueryException, JobInfo, LoadJobConfiguration}
 import com.google.cloud.http.BaseHttpServiceException
 import com.typesafe.scalalogging.StrictLogging
+import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{Path, RemoteIterator}
 import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
 

--- a/src/main/scala/com/google/cloud/spark/bigquery/BigQueryWriteHelper.scala
+++ b/src/main/scala/com/google/cloud/spark/bigquery/BigQueryWriteHelper.scala
@@ -19,7 +19,7 @@ import java.util.UUID
 
 import com.google.cloud.bigquery.{BigQuery, BigQueryException, JobInfo, LoadJobConfiguration}
 import com.google.cloud.http.BaseHttpServiceException
-import com.typesafe.scalalogging.StrictLogging
+import com.typesafe.scalalogging.Logger
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{Path, RemoteIterator}
 import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
@@ -30,10 +30,9 @@ case class BigQueryWriteHelper(bigQuery: BigQuery,
                                sqlContext: SQLContext,
                                saveMode: SaveMode,
                                options: SparkBigQueryOptions,
-                               data: DataFrame) extends StrictLogging {
+                               data: DataFrame) {
 
-  import org.apache.spark.sql.SaveMode
-
+  private val logger = Logger(getClass)
   val conf = sqlContext.sparkContext.hadoopConfiguration
 
   val temporaryGcsPath = {
@@ -126,8 +125,9 @@ case class BigQueryWriteHelper(bigQuery: BigQuery,
  * @param conf the hadoop configuration
  */
 case class IntermediateDataCleaner(path: Path, conf: Configuration)
-  extends Thread
-    with StrictLogging {
+  extends Thread {
+  private val logger = Logger(getClass)
+
   def deletePath: Unit =
     try {
       val fs = path.getFileSystem(conf)

--- a/src/main/scala/com/google/cloud/spark/bigquery/BigQueryWriteHelper.scala
+++ b/src/main/scala/com/google/cloud/spark/bigquery/BigQueryWriteHelper.scala
@@ -20,7 +20,6 @@ import java.util.UUID
 import com.google.cloud.bigquery.{BigQuery, BigQueryException, JobInfo, LoadJobConfiguration}
 import com.google.cloud.http.BaseHttpServiceException
 import com.typesafe.scalalogging.StrictLogging
-import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{Path, RemoteIterator}
 import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
 

--- a/src/main/scala/com/google/cloud/spark/bigquery/BigQueryWriteHelper.scala
+++ b/src/main/scala/com/google/cloud/spark/bigquery/BigQueryWriteHelper.scala
@@ -131,7 +131,9 @@ case class IntermediateDataCleaner(path: Path, conf: Configuration)
   def deletePath: Unit =
     try {
       val fs = path.getFileSystem(conf)
-      fs.delete(path, true)
+      if(fs.exists(path)) {
+        fs.delete(path, true)
+      }
     } catch {
       case e: Exception => logger.error(s"Failed to delete path $path", e)
     }

--- a/src/main/scala/com/google/cloud/spark/bigquery/examples/Shakespeare.scala
+++ b/src/main/scala/com/google/cloud/spark/bigquery/examples/Shakespeare.scala
@@ -26,7 +26,7 @@ object Shakespeare {
 
     // Use the Cloud Storage bucket for temporary BigQuery export data used
     // by the connector. This assumes the Cloud Storage connector for
-    // Hadoop is configured.r
+    // Hadoop is configured.
     val bucket = spark.sparkContext.hadoopConfiguration.get("fs.gs.system.bucket")
     spark.conf.set("temporaryGcsBucket", bucket)
 

--- a/src/main/scala/com/google/cloud/spark/bigquery/examples/Shakespeare.scala
+++ b/src/main/scala/com/google/cloud/spark/bigquery/examples/Shakespeare.scala
@@ -15,23 +15,32 @@
  */
 package com.google.cloud.spark.bigquery.examples
 
-import java.nio.file.Files
-
 import com.google.cloud.spark.bigquery._
-import com.typesafe.scalalogging.Logger
 import org.apache.spark.sql.SparkSession
 
 object Shakespeare {
-  private val log = Logger(getClass)
   def main(args: Array[String]) {
-    val spark = SparkSession.builder().appName("test").getOrCreate()
-    val sc = spark.sparkContext
+    val spark = SparkSession.builder()
+      .appName("spark-bigquery-demo")
+      .getOrCreate()
 
-    var df = spark.read.bigquery("publicdata.samples.shakespeare").cache()
-    df.show()
-    df.printSchema()
-    val path = Files.createTempDirectory("spark-bigquery").resolve("out")
-    log.warn("Writing table out to {}", path)
-    df.write.csv(path.toString)
+    // Use the Cloud Storage bucket for temporary BigQuery export data used
+    // by the connector. This assumes the Cloud Storage connector for
+    // Hadoop is configured.r
+    val bucket = spark.sparkContext.hadoopConfiguration.get("fs.gs.system.bucket")
+    spark.conf.set("temporaryGcsBucket", bucket)
+
+    // Load data in from BigQuery.
+    val wordsDF = spark.read.bigquery("publicdata.samples.shakespeare").cache()
+    wordsDF.show()
+    wordsDF.printSchema()
+    wordsDF.createOrReplaceTempView("words")
+
+    // Perform word count.
+     val wordCountDF = spark.sql(
+      "SELECT word, SUM(word_count) AS word_count FROM words GROUP BY word")
+
+    // Saving the data to BigQuery
+    wordCountDF.write.bigquery("wordcount_dataset.wordcount_output")
   }
 }

--- a/src/main/scala/com/google/cloud/spark/bigquery/package.scala
+++ b/src/main/scala/com/google/cloud/spark/bigquery/package.scala
@@ -24,4 +24,10 @@ package object bigquery {
       reader.format("bigquery").option("table", table).load()
     }
   }
+
+  implicit class BigQueryDataFrameWriter[T](writer: DataFrameWriter[T]) {
+    def bigquery(table: String): Unit = {
+      writer.format("bigquery").option("table", table).save()
+    }
+  }
 }


### PR DESCRIPTION
- A NPE in the shutdown hook has occurred in case the delete had succeeded in the first time. The method now verifies the path exists before trying to delete it.
- Added support for data.write.bigquery("table") implicit import, fixed regression caused by relying of shaded scalalogging
