### PR TITLE
Fix filter when sending load job to Big Query

### DIFF
--- a/src/main/scala/com/google/cloud/spark/bigquery/BigQueryWriteHelper.scala
+++ b/src/main/scala/com/google/cloud/spark/bigquery/BigQueryWriteHelper.scala
@@ -73,9 +73,10 @@ case class BigQueryWriteHelper(bigQuery: BigQuery,
 
   def loadDataToBigQuery(): Unit = {
     val fs = temporaryGcsPath.getFileSystem(conf)
+    val format = options.intermediateFormat.getType.toLowerCase
     val sourceUris = ToIterator(fs.listFiles(temporaryGcsPath, false))
       .map(_.getPath.toString)
-      .filter(!_.endsWith("_SUCCESS"))
+      .filter(_.endsWith(s".$format"))
       .toList
       .asJava
 


### PR DESCRIPTION
Currently, when writing delta tables we have _committed _started _SUCCESS file. So we need to filter only using the temporary format