### PR TITLE
Fixing log severity

### DIFF
--- a/src/main/scala/com/google/cloud/spark/bigquery/direct/DirectBigQueryRelation.scala
+++ b/src/main/scala/com/google/cloud/spark/bigquery/direct/DirectBigQueryRelation.scala
@@ -109,8 +109,14 @@ private[bigquery] class DirectBigQueryRelation(
       // This is spammy, but it will make it clear to users the number of partitions they got and
       // why.
       if (!numPartitionsRequested.equals(partitions.length)) {
-        log.warn(s"Requested $numPartitionsRequested partitions, but only received " +
-          s"${partitions.length} from the BigQuery Storage API for session ${session.getName}.")
+        log.info(
+          s"""Requested $numPartitionsRequested partitions, but only
+             |received ${partitions.length} from the BigQuery Storage API for
+             |session ${session.getName}. Notice that the number of streams in
+             |actual may be lower than the requested number, depending on the
+             |amount parallelism that is reasonable for the table and the
+             |maximum amount of parallelism allowed by the system."""
+            .stripMargin.replace('\n',' '))
       }
 
       BigQueryRDD.scanTable(

--- a/src/test/scala/com/google/cloud/spark/bigquery/DirectBigQueryRelationSuite.scala
+++ b/src/test/scala/com/google/cloud/spark/bigquery/DirectBigQueryRelationSuite.scala
@@ -120,33 +120,35 @@ class DirectBigQueryRelationSuite
 
   test("old filter behaviour, with filter option") {
     val r = new DirectBigQueryRelation(
-      SparkBigQueryOptions(ID, PROJECT_ID, combinePushedDownFilters = false, filter = Some("f>1")), TABLE)(sqlCtx)
-    checkFilters(r,"f>1", Array(GreaterThan("a",2)),"f>1")
+      SparkBigQueryOptions(
+        ID, PROJECT_ID, combinePushedDownFilters = false, filter = Some("f>1")
+      ), TABLE)(sqlCtx)
+    checkFilters(r, "f>1", Array(GreaterThan("a", 2)), "f>1")
   }
 
   test("old filter behaviour, no filter option") {
     val r = new DirectBigQueryRelation(
       SparkBigQueryOptions(ID, PROJECT_ID, combinePushedDownFilters = false), TABLE)(sqlCtx)
-    checkFilters(r,"", Array(GreaterThan("a",2)),"a > 2")
+    checkFilters(r, "", Array(GreaterThan("a", 2)), "a > 2")
   }
 
   test("new filter behaviour, with filter option") {
     val r = new DirectBigQueryRelation(
       SparkBigQueryOptions(ID, PROJECT_ID, filter = Some("f>1")), TABLE)(sqlCtx)
-    checkFilters(r,"(f>1)", Array(GreaterThan("a",2)),"(f>1) AND (a > 2)")
+    checkFilters(r, "(f>1)", Array(GreaterThan("a", 2)), "(f>1) AND (a > 2)")
   }
 
   test("new filter behaviour, no filter option") {
     val r = new DirectBigQueryRelation(
       SparkBigQueryOptions(ID, PROJECT_ID), TABLE)(sqlCtx)
-    checkFilters(r,"", Array(GreaterThan("a",2)),"(a > 2)")
+    checkFilters(r, "", Array(GreaterThan("a", 2)), "(a > 2)")
   }
 
   def checkFilters(
       r: DirectBigQueryRelation,
-      resultWithoutFilters:String,
+      resultWithoutFilters: String,
       filters: Array[Filter],
-      resultWithFilters:String
+      resultWithFilters: String
       ): Unit = {
     val result1 = r.getCompiledFilter(Array())
     result1 shouldBe resultWithoutFilters

--- a/src/test/scala/com/google/cloud/spark/bigquery/it/SparkBigQueryEndToEndITSuite.scala
+++ b/src/test/scala/com/google/cloud/spark/bigquery/it/SparkBigQueryEndToEndITSuite.scala
@@ -334,16 +334,16 @@ class SparkBigQueryEndToEndITSuite extends FunSuite
   test("keeping filters behaviour") {
     val newBehaviourWords = extractWords(
       spark.read.format("bigquery")
-      .option("table","publicdata.samples.shakespeare")
-      .option("filter","length(word) = 1")
-      .option("combinePushedDownFilters","true")
+      .option("table", "publicdata.samples.shakespeare")
+      .option("filter", "length(word) = 1")
+      .option("combinePushedDownFilters", "true")
       .load())
 
     val oldBehaviourWords = extractWords(
       spark.read.format("bigquery")
-      .option("table","publicdata.samples.shakespeare")
-      .option("filter","length(word) = 1")
-      .option("combinePushedDownFilters","false")
+      .option("table", "publicdata.samples.shakespeare")
+      .option("filter", "length(word) = 1")
+      .option("combinePushedDownFilters", "false")
       .load())
 
     newBehaviourWords should equal (oldBehaviourWords)


### PR DESCRIPTION
Following https://stackoverflow.com/questions/58766857/ it appears that having a warn level for this message is too severe, is it may occur according to the BigQuery Storage API, see the description of the requestedStreams parameter in [the API](https://googleapis.dev/java/google-cloud-clients/latest/com/google/cloud/bigquery/storage/v1beta1/BigQueryStorageClient.html#createReadSession-com.google.cloud.bigquery.storage.v1beta1.TableReferenceProto.TableReference-java.lang.String-int-).